### PR TITLE
Add rule for ordering extend / includes

### DIFF
--- a/css.md
+++ b/css.md
@@ -22,7 +22,7 @@ CSS Coding Standards
 
 ## Formatting
 
-* Sort declarations alphabetically, except for vendor prefixes.
+* Sort declarations alphabetically, except for vendor prefixes, variables and mixins. Variables and mixins (like `@include` or `@extend`) always belong to the top followed by an empty line.
 * Use full 6 digits, lower cased hex color codes `#00aa00`. When using SCSS, the `rgba()` method will support hex colors as a param, e.g., `rgba(#00ff00, 0.5)`. In raw CSS it is permitted to break this rule when using `rgba()` only.
 * Use `//` for comment blocks (instead of `/* */`).
 * Use single line quotes `'` for strings, e.g. `url('http://...')`.
@@ -110,7 +110,7 @@ Use the following configuration when using the [CSScomb tool](http://csscomb.com
     "leading-zero": true,
     "quotes": "single",
     "remove-empty-rulesets": true,
-    "sort-order": [],
+    "sort-order": [["$variable"], ["$include"]],
     "sort-order-fallback": "abc",
     "space-after-colon": " ",
     "space-after-combinator": " ",


### PR DESCRIPTION
@tgolen 
@shawnborton 

For example:
```
p {
    color: #00ff00;
    background: #ff0000;
    @include box-shadow(0 0 1px #000000);
}
```

Should be:
```
p {
    @include box-shadow(0 0 1px #000000);

    background: #ff0000;
    color: #00ff00;
}
```

Same goes for `@extend`. Also added variables to the CSScomb configuration but we actually never define variables in blocks so we should be fine.