### PR TITLE
Fix some typos and broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,3 @@ Please propose modifications through pull requests.
 
 # Other
 * [General Best Practices](https://github.com/Expensify/Style-Guide/blob/master/general.md)
-* [API](https://github.com/Expensify/Style-Guide/blob/master/api.md)
-
-

--- a/java.md
+++ b/java.md
@@ -11,7 +11,7 @@
  
 ## Introduction
 
-Our Java style guide is tightly based on the [Google Java Style](https://google-styleguide.googlecode.com/svn/trunk/javaguide.html), with a few notable differences. This document focuses on style guides and coding standards that differ from, or extend it. If a rule is not defined in this document, assume the Google style should be used.
+Our Java style guide is tightly based on the [Google Java Style](https://google.github.io/styleguide/javaguide.html), with a few notable differences. This document focuses on style guides and coding standards that differ from, or extend it. If a rule is not defined in this document, assume the Google style should be used.
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -19,7 +19,7 @@ Our Java style guide is tightly based on the [Google Java Style](https://google-
 
 ### Class member ordering
 
-From [Google's style guide](https://google-styleguide.googlecode.com/svn/trunk/javaguide.html#s3.4.2-class-member-ordering):
+From [Google's style guide](https://google.github.io/styleguide/javaguide.html#s3.4.2-ordering-class-contents):
 > The ordering of the members of a class can have a great effect on learnability, but there is no single correct recipe for how to do it. Different classes may order their members differently.
 
 > What is important is that each class order its members in ___some___ _logical order_, which its maintainer could explain if asked. For example, new methods are not just habitually added to the end of the class, as that would yield "chronological by date added" ordering, which is not a logical ordering.

--- a/javascript.md
+++ b/javascript.md
@@ -253,7 +253,7 @@ There are a few things that we have customized for our tastes which will take pr
 
 ## Module Pattern
 
-When you hear "module pattern" in the context of javascript think singleton pattern. The way singletons or modules are usually implemented in js is by using a plain js object. Typically
+When you hear "module pattern" in the context of JavaScript think singleton pattern. The way singletons or modules are usually implemented in JS is by using a plain JS object. Typically
 
 We set variables and functions as properties of the object so you won't see prototype anywhere in a module.
 Variables are prefixed with `_` since they're usually "private" to the module and if they're made available to the outside world it's usually through getters and setters
@@ -287,7 +287,7 @@ We only know of one **good reason** to use IIFEs and that is to **take advantage
 
 What the code above does is define a function that returns a closure and immediately invoke the function. You can think of a closure like a box with two things in it: a function and a context where the context is just a collection of variables that are available to the function. In the case above the IIFE defines (and invokes) a function that returns a closure: the inner function + the variable `id`.
 
-Closures are used in js to emulate private variables. In js there's no such thing as private variables (surprise!) but by leveraging closures you can emulate private variables and this is illustrated in the `setTimeout` example above where the variable id is inaccessible from outside of that function.
+Closures are used in JS to emulate private variables. In JS there's no such thing as private variables (surprise!) but by leveraging closures you can emulate private variables and this is illustrated in the `setTimeout` example above where the variable id is inaccessible from outside of that function.
 
 Note that we **do not recommend using IIFEs to emulate private variables** in Expensify's code bases because the convention of prefixing private variables with an underscore serves the same purpose and allows you to access the variables from outside the function **for debugging purposes**: think about accessing these from the Safari / Chrome console while debugging our iOS or web app.
 
@@ -341,13 +341,13 @@ renderApplication(appRenderer);
 
 ## Publisher / Subscriber
 
-This one isn't specific to js but we think it's worth mentioning because
+This one isn't specific to JS but we think it's worth mentioning because
 
-1.- We use it heavily on web and mobile
+1. We use it heavily on web and mobile.
 
-2.- We should be using it more on mobile
+2. We should be using it more on mobile.
 
-3.- For new hires?
+3. We want new hires to understand it.
 
 The publisher / subscriber pattern helps decouple objects from one another by changing the paradigm a bit from having objects directly call one another (thus coupling one to the public API of the other) to having objects publish (send / emit) events or messages while others subscribe (react) to them and using an event bus to send and receive these messages, which in our case is the `PubSub` library.
 

--- a/javascript.md
+++ b/javascript.md
@@ -90,7 +90,7 @@ There are a few things that we have customized for our tastes which will take pr
         foo      : 'bar',
         foobar   : 'foobar',
         foobarbaz: 'foobarbaz',
-    }
+    };
     ```
 
 ## Naming Conventions
@@ -268,7 +268,7 @@ In Expensify this looks like this
 ```js
 (function () {
     // function body
-}());
+})();
 ```
 
 and a perfect example of this is [setTimeout (on mobile)](https://github.com/Expensify/Mobile-Expensify/blob/18781e7c7115355a24fadcf04c6326f934ce4f7d/JavaScript/yapl.js#L218-L232).
@@ -280,7 +280,7 @@ this.setTimeout = (function () {
         yaplCall('yaplSetTimeout', fun, milliseconds);
         return ++id;
     };
-}());
+})();
 ```
 
 We only know of one **good reason** to use IIFEs and that is to **take advantage of closures**.
@@ -323,7 +323,7 @@ var appRenderer = ConsoleRenderer;
     };
 
     renderer.render(app);
-}(appRenderer));
+})(appRenderer);
 
 // The alternative with clearer syntax
 // Note that in this case renderApplication is added to the current scope

--- a/php.md
+++ b/php.md
@@ -12,12 +12,13 @@ PHP Coding Standard
 	1. [Constants](#constants)
    	1. [Properties](#properties)
    	1. [Methods](#methods)
-1. [Control Structures](#controlStructures)
+1. [Control Structures](#control-structures)
 1. [Closures](#closures)
 1. [Variables](#variables)
 1. [SQL](#sql)
 1. [HTML](#html)
-1. [Blank Lines](#blankLines)
+1. [PHPDocs](#phpdocs)
+1. [Blank Lines](#blank-lines)
 
 
 ## Introduction
@@ -890,7 +891,9 @@ $query = "SELECT
 
 - For complex HTML pages, you MUST use a templating engine
 - The PHP short tag `<?=` can be used to print $variable
-- When adding control structures in templates (if, for, etc) the markup inside them must be intended, same as code would. Good:
+- When adding control structures in templates (if, for, etc) the markup inside them must be intended the same as code would be. 
+
+Good:
 ```
 <p>Some html</p>
 <% if (something) { %>


### PR DESCRIPTION
Hi, Expensify!

I was preparing for my onsite interview in Portland tomorrow and noticed a few typos and broken links in the style guide. I thought you might appreciate it if I took a quick moment to fix them so you don't have to - especially since they're probably not a super high priority for you guys. (But it's fun for me!)

There aren't that many changes, but they're primarily comprised of three types:
- Fixing or deleting broken links as appropriate - both internal and external (except links to private repos, of course)
- Correcting a few typos and inconsistent word usage
- Changing a few things that seem to be inconsistent between guidelines (e.g. Rule #1 not being demonstrated correctly in Rule #5's example.)

I hope you find this helpful!